### PR TITLE
feat(billing): allow model exclusions from Codex Fast pricing

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,18 @@ plugins:
       enabled: true
       debug: false # 是否记录 debug 日志，例如路由日志、匹配参考价日志
       codex_fast_mode_billing: false # Codex 的 priority 请求按 2.5 倍计费
+      codex_fast_mode_billing_excluded_models: "" # 不叠加 Fast 倍率的计费模型 ID，逗号分隔
       state_file: "plugins/cpa-key-billing-state-v1.db"
 ```
 
 `codex_fast_mode_billing` 开启后，请求 Codex 上游时在请求中指定 `service_tier=priority`，按普通费用的 **2.5 倍**结算。
+
+如果某些模型的价格已经包含 Fast 加价，可以将其加入
+`codex_fast_mode_billing_excluded_models`，例如 `"my-fast-alias, another-model"`。
+列表默认为空；按计费模型 ID 匹配，忽略大小写和末尾推理后缀，保留路由前缀，不支持通配符。
+命中的模型仍按已有的自定义价、内置价或参考价结算，只跳过额外的 2.5 倍倍率。
+此设置不会修改请求的 `service_tier`、模型路由或上游执行方式；未定价请求仍遵循原有规则。
+配置变更仅影响后续用量的结算，已保存的历史费用和倍率保持不变。
 
 > [!WARNING]
 > 升级前请备份数据文件。

--- a/internal/billing/account.go
+++ b/internal/billing/account.go
@@ -54,6 +54,7 @@ func (s *Store) recordUsage(event UsageEvent, failure *RequestError) {
 	updateResult(s, func(state *State) (struct{}, Changes) {
 		// ServiceTier is the client-requested tier, not the upstream response tier.
 		if s.cfg.CodexFastModeBilling && price.Source != PriceSourceNone && event.Breakdown.Billable() &&
+			!s.cfg.excludesCodexFastBilling(billingModel) &&
 			strings.EqualFold(strings.TrimSpace(event.Provider), "codex") &&
 			strings.EqualFold(strings.TrimSpace(event.AuthType), "oauth") &&
 			strings.EqualFold(strings.TrimSpace(event.ServiceTier), "priority") {

--- a/internal/billing/config.go
+++ b/internal/billing/config.go
@@ -12,10 +12,11 @@ import (
 const DefaultStateFile = "plugins/cpa-key-billing-state-v1.db"
 
 type Config struct {
-	Enabled              bool   `yaml:"enabled"`
-	Debug                bool   `yaml:"debug"`
-	StateFile            string `yaml:"state_file"`
-	CodexFastModeBilling bool   `yaml:"codex_fast_mode_billing"`
+	Enabled                            bool   `yaml:"enabled"`
+	Debug                              bool   `yaml:"debug"`
+	StateFile                          string `yaml:"state_file"`
+	CodexFastModeBilling               bool   `yaml:"codex_fast_mode_billing"`
+	CodexFastModeBillingExcludedModels string `yaml:"codex_fast_mode_billing_excluded_models"`
 }
 
 func DefaultConfig() Config {
@@ -60,4 +61,18 @@ func (c Config) normalized() Config {
 		c.StateFile = DefaultStateFile
 	}
 	return c
+}
+
+// Exclusions use billing model IDs and preserve routing prefixes.
+func (c Config) excludesCodexFastBilling(model string) bool {
+	model = NormalizeModelID(ModelWithoutThinkingSuffix(model))
+	if model == "" {
+		return false
+	}
+	for _, excluded := range strings.Split(c.CodexFastModeBillingExcludedModels, ",") {
+		if model == NormalizeModelID(ModelWithoutThinkingSuffix(strings.TrimSpace(excluded))) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/billing/config_test.go
+++ b/internal/billing/config_test.go
@@ -7,12 +7,34 @@ func TestDecodeConfigDefaults(t *testing.T) {
 	if errDecode != nil {
 		t.Fatalf("DecodeConfig: %v", errDecode)
 	}
-	if !cfg.Enabled || cfg.Debug || cfg.CodexFastModeBilling || cfg.StateFile != DefaultStateFile {
+	if !cfg.Enabled || cfg.Debug || cfg.CodexFastModeBilling || cfg.CodexFastModeBillingExcludedModels != "" || cfg.StateFile != DefaultStateFile {
 		t.Fatalf("config = %+v", cfg)
 	}
 	cfg, errDecode = DecodeConfig([]byte("enabled: true\ndebug: true\ncodex_fast_mode_billing: true\n"))
 	if errDecode != nil || !cfg.Debug || !cfg.CodexFastModeBilling {
 		t.Fatalf("config = %+v, error = %v", cfg, errDecode)
+	}
+}
+
+func TestDecodeCodexFastBillingExclusions(t *testing.T) {
+	cfg, errDecode := DecodeConfig([]byte("codex_fast_mode_billing: true\ncodex_fast_mode_billing_excluded_models: 'fast-alias, Route/SECOND , , '\n"))
+	if errDecode != nil {
+		t.Fatal(errDecode)
+	}
+	for _, test := range []struct {
+		model    string
+		excluded bool
+	}{
+		{"fast-alias", true}, {"FAST-ALIAS(high)", true}, {"route/second", true},
+		{"second", false}, {"prefix/fast-alias", false}, {"fast-alias-other", false}, {"", false},
+	} {
+		if got := cfg.excludesCodexFastBilling(test.model); got != test.excluded {
+			t.Fatalf("model %q: excluded=%t, want %t", test.model, got, test.excluded)
+		}
+	}
+	cfg, errDecode = DecodeConfig([]byte("codex_fast_mode_billing_excluded_models: ''\n"))
+	if errDecode != nil || cfg.excludesCodexFastBilling("fast-alias") {
+		t.Fatalf("empty exclusions: %+v, error=%v", cfg, errDecode)
 	}
 }
 

--- a/internal/plugin/app.go
+++ b/internal/plugin/app.go
@@ -138,6 +138,11 @@ func registration() Registration {
 					Description: "请求 Codex 上游时指定 priority 档位，按 2.5 倍计费",
 				},
 				{
+					Name:        "codex_fast_mode_billing_excluded_models",
+					Type:        "string",
+					Description: "不叠加 Codex Fast 2.5 倍计费的模型 ID，逗号分隔；仅影响计费，不改变请求档位",
+				},
+				{
 					Name:        "state_file",
 					Type:        "string",
 					Description: "计费数据库文件路径",

--- a/internal/plugin/app_test.go
+++ b/internal/plugin/app_test.go
@@ -41,7 +41,8 @@ func TestRegisterDeclaresExpectedCapabilities(t *testing.T) {
 		fields[field.Name] = field
 	}
 	if fields["state_file"].Type != "string" || fields["debug"].Type != "boolean" ||
-		fields["codex_fast_mode_billing"].Type != "boolean" || fields["enabled"].Name != "" {
+		fields["codex_fast_mode_billing"].Type != "boolean" ||
+		fields["codex_fast_mode_billing_excluded_models"].Type != "string" || fields["enabled"].Name != "" {
 		t.Fatalf("ConfigFields = %+v", registration.Metadata.ConfigFields)
 	}
 }

--- a/internal/plugin/fast_billing_exclusions_test.go
+++ b/internal/plugin/fast_billing_exclusions_test.go
@@ -1,0 +1,127 @@
+package plugin
+
+import (
+	"testing"
+	"time"
+
+	"cpa-key-billing/internal/billing"
+)
+
+func fastExclusionUsage(app *App, model, alias string) UsageRecord {
+	return UsageRecord{
+		Model: model, Alias: alias, APIKey: testAPIKey,
+		Provider: "codex", AuthType: "oauth", ServiceTier: "priority",
+		RequestedAt: app.store.Now().Add(-time.Second),
+		Detail:      UsageDetail{InputTokens: 200, CacheReadTokens: 100, OutputTokens: 100, TotalTokens: 300},
+	}
+}
+
+func TestCodexFastBillingExclusions(t *testing.T) {
+	for _, test := range []struct {
+		name, excluded, alias, tier, provider, authType string
+		enabled                                         bool
+		factor                                          float64
+	}{
+		{"empty-default", "", "fast-alias", "priority", "codex", "oauth", true, 2.5},
+		{"excluded", "fast-alias", "fast-alias", "priority", "codex", "oauth", true, 1},
+		{"list-and-case", "other, FAST-ALIAS ,", "fast-alias", "priority", "codex", "oauth", true, 1},
+		{"thinking-suffix", "fast-alias", "fast-alias(high)", "priority", "codex", "oauth", true, 1},
+		{"prefixed-exclusion", "route/fast-alias", "route/fast-alias", "priority", "codex", "oauth", true, 1},
+		{"prefix-is-significant", "fast-alias", "route/fast-alias", "priority", "codex", "oauth", true, 2.5},
+		{"different-alias", "fast-alias", "fast-alias-other", "priority", "codex", "oauth", true, 2.5},
+		{"upstream-is-not-alias", flowModel, "fast-alias", "priority", "codex", "oauth", true, 2.5},
+		{"no-wildcards", "*-alias", "fast-alias", "priority", "codex", "oauth", true, 2.5},
+		{"standard", "", "fast-alias", "default", "codex", "oauth", true, 1},
+		{"disabled", "", "fast-alias", "priority", "codex", "oauth", false, 1},
+		{"other-provider", "", "fast-alias", "priority", "openai", "oauth", true, 1},
+		{"api-key", "", "fast-alias", "priority", "codex", "api_key", true, 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			app, statePath := newAppWithPriceAndState(t, true)
+			cfg := billing.Config{Enabled: true, StateFile: statePath,
+				CodexFastModeBilling: test.enabled, CodexFastModeBillingExcludedModels: test.excluded}
+			if err := app.store.Configure(cfg); err != nil {
+				t.Fatal(err)
+			}
+			cacheRead, cacheWrite := 0.1, 1.25
+			if _, err := app.store.UpsertPrice(billing.CustomPrice{
+				ModelID:    billing.ModelWithoutThinkingSuffix(test.alias),
+				PriceRates: billing.PriceRates{InputPer1M: 1, OutputPer1M: 2, CacheReadPer1M: &cacheRead, CacheWritePer1M: &cacheWrite},
+			}); err != nil {
+				t.Fatal(err)
+			}
+			record := fastExclusionUsage(app, flowModel, test.alias)
+			record.ServiceTier, record.Provider, record.AuthType = test.tier, test.provider, test.authType
+			publishUsageRecord(t, app, record)
+			entries := requestEventEntries(t, app)
+			if len(entries) != 1 {
+				t.Fatalf("events = %+v", entries)
+			}
+			entry := entries[0]
+			wantMultiplier := test.factor
+			if wantMultiplier == 1 {
+				wantMultiplier = 0
+			}
+			if entry.Cost.Multiplier != wantMultiplier || entry.ServiceTier != test.tier || entry.PriceSource != billing.PriceSourceCustom {
+				t.Fatalf("unexpected billing metadata: %+v", entry)
+			}
+			assertCostClose(t, entry.Cost.TotalUSD, 0.00031*test.factor)
+			assertCostClose(t, entry.Cost.AppliedInputPer1M, test.factor)
+			assertCostClose(t, entry.Cost.AppliedOutputPer1M, 2*test.factor)
+			assertCostClose(t, entry.Cost.AppliedCacheReadPer1M, 0.1*test.factor)
+			assertCostClose(t, entry.Cost.AppliedCacheWritePer1M, 1.25*test.factor)
+			if entry.Cost.UncachedInputTokens != 100 || entry.Cost.CacheReadTokens != 100 || entry.Cost.BilledOutputTokens != 100 {
+				t.Fatalf("exclusion changed token usage: %+v", entry.Cost)
+			}
+		})
+	}
+}
+
+func TestCodexFastExclusionPriceSourcesAndHistory(t *testing.T) {
+	for _, test := range []struct {
+		model  string
+		source billing.PriceSource
+	}{
+		{flowModel, billing.PriceSourceCustom},
+		{"gpt-4o", billing.PriceSourceReference},
+		{"gpt-image-1.5", billing.PriceSourceBuiltin},
+	} {
+		t.Run(string(test.source), func(t *testing.T) {
+			app, statePath := newAppWithPriceAndState(t, true)
+			cfg := billing.Config{Enabled: true, StateFile: statePath, CodexFastModeBilling: true}
+			if err := app.store.Configure(cfg); err != nil {
+				t.Fatal(err)
+			}
+			record := fastExclusionUsage(app, test.model, test.model)
+			record.RequestedAt = app.store.Now().Add(-2 * time.Second)
+			publishUsageRecord(t, app, record)
+			cfg.CodexFastModeBillingExcludedModels = test.model
+			if err := app.store.Configure(cfg); err != nil {
+				t.Fatal(err)
+			}
+			record.RequestedAt = record.RequestedAt.Add(time.Second)
+			publishUsageRecord(t, app, record)
+			app.Shutdown()
+			reopened := newTestApp(t)
+			t.Cleanup(reopened.Shutdown)
+			if err := reopened.store.Configure(cfg); err != nil {
+				t.Fatal(err)
+			}
+			entries := requestEventEntries(t, reopened)
+			if len(entries) != 2 {
+				t.Fatalf("persisted events = %+v", entries)
+			}
+			current, historical := entries[0], entries[1]
+			if current.PriceSource != test.source || historical.PriceSource != test.source || current.Cost.Multiplier != 0 || historical.Cost.Multiplier != 2.5 {
+				t.Fatalf("exclusion changed source or historical multiplier: %+v", entries)
+			}
+			if current.Cost.TotalUSD <= 0 {
+				t.Fatal("exclusion made a priced model free")
+			}
+			assertCostClose(t, historical.Cost.TotalUSD, current.Cost.TotalUSD*2.5)
+			if current.ServiceTier != "priority" || historical.ServiceTier != "priority" {
+				t.Fatal("exclusion changed service tier")
+			}
+		})
+	}
+}


### PR DESCRIPTION
A model alias may already have a Fast surcharge included in its price. Enabling `codex_fast_mode_billing` currently multiplies that price by another 2.5 whenever its Codex OAuth usage record reports `priority`.

Add `codex_fast_mode_billing_excluded_models`, a comma-separated list of billing model IDs that skip only the additional Fast multiplier. The default is empty, preserving existing behavior. Excluded models still incur their resolved custom, built-in, or reference price, and retain their request tier, routing, token accounting, and historical costs.

For example, inside the plugin configuration:

```yaml
codex_fast_mode_billing: true
codex_fast_mode_billing_excluded_models: "my-fast-alias, another-model"
```

Matching ignores case and trailing thinking suffixes, preserves routing prefixes, and uses the billing model rather than the upstream model. Wildcards are not supported. The option is exposed in plugin configuration metadata and documented in the README.

Validation:

- `go test -count=1 ./...` and `go test -race ./...`
- `go vet ./...`, `go mod tidy -diff`, formatting and embedded JavaScript syntax checks
- `scripts/e2e_cpa_billing.sh v7.2.143` (45 dummy upstream requests)

Regression coverage includes empty/default behavior, exact alias and prefix matching, thinking suffixes, provider/auth/tier gating, all three price sources, retained token counts, and persisted historical costs/multipliers after reconfiguration and reopening SQLite.
