### PR TITLE
feat: add an optional per-key model catalog proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ plugins/cpa-key-billing.dll      # Windows
 
 ## 配置
 
+如需根据每个 API Key 的路由权限过滤客户端看到的模型列表，可使用可选的
+[模型目录代理](docs/model-catalog-proxy.md)。它独立运行，保留模型元数据，
+不影响推理请求和计费；路由权限仍由 Key Billing 管理。
+
 在 CLIProxyAPI 配置文件中加入：
 
 ```yaml

--- a/cmd/cpa-model-catalog-proxy/main.go
+++ b/cmd/cpa-model-catalog-proxy/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+
+	"cpa-key-billing/internal/catalogproxy"
+)
+
+func run() error {
+	listen := flag.String("listen", "127.0.0.1:18318", "HTTP listen address")
+	upstream := flag.String("upstream", "http://127.0.0.1:8317", "CPA HTTP(S) origin")
+	flag.Parse()
+	proxy, err := catalogproxy.New(*upstream)
+	if err != nil {
+		return err
+	}
+	return http.ListenAndServe(*listen, proxy)
+}
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, "model catalog proxy:", err)
+		os.Exit(1)
+	}
+}

--- a/docs/model-catalog-proxy.md
+++ b/docs/model-catalog-proxy.md
@@ -1,0 +1,77 @@
+# Per-key model discovery
+
+The optional `cpa-model-catalog-proxy` companion filters CPA model catalogs using
+the caller's Key Billing routing permissions. It runs as a separate HTTP
+process and uses the existing `/v0/resource/plugins/cpa-key-billing/routing`
+endpoint in v1.3.3 and later. The plugin binary and CPA require no changes.
+
+## Run
+
+```sh
+go build -o cpa-model-catalog-proxy ./cmd/cpa-model-catalog-proxy
+./cpa-model-catalog-proxy -listen 127.0.0.1:18318 -upstream http://127.0.0.1:8317
+```
+
+Use the original CPA listener as the upstream, not this proxy or an address
+whose model routes lead back to it. Both HTTP and HTTPS upstream origins are
+supported. The default listener is loopback.
+
+Clients can use the companion as their CPA base URL. Alternatively, send only
+model-list requests through it in an existing reverse proxy. For Nginx, inside
+the API server block:
+
+```nginx
+location ~ ^/(v1/models|models|backend-api/codex/models|codex/models)$ {
+    proxy_pass http://127.0.0.1:18318;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_cache off;
+}
+```
+
+Keep the administrator's model-pricing discovery connected directly to CPA so
+that its complete catalog is available. Direct CPA connections bypass this
+display filter; Key Billing's request-time enforcement remains authoritative.
+
+## Filtering rules
+
+- Each successful model-list response is intersected with the current caller's
+  route model scope. An empty scope means unrestricted models; matching is
+  case-insensitive and exact, as in Key Billing. No model names are hardcoded.
+- Credential-bound routes also restrict catalog ownership to the credential
+  providers reported by Key Billing. Codex corresponds to `owned_by: openai`.
+  Native Codex catalogs omit ownership and are treated as Codex-only. Unknown
+  owners are hidden when a credential-provider restriction applies, and entries
+  reported as missing or disabled do not grant a provider.
+- OpenAI `data` and native Codex `models` arrays are supported. Retained model
+  metadata, including instructions, capabilities, and speed choices, is preserved.
+- The catalog and routing permissions are fetched on every request. Filtered
+  responses use `Cache-Control: private, no-store`, and shared cache validators
+  are removed. Clients must still refresh any catalog they already hold.
+- CPA authenticates the catalog request first. The routing lookup uses the same
+  downstream key, normalized to Bearer authentication, without a management key.
+  Conflicting credentials are rejected. Permission redirects are not followed.
+- Missing, invalid, or unavailable routing permissions produce HTTP 502 instead
+  of an unfiltered model list. The Key must be tracked in Key Billing, for example
+  by synchronizing configured keys and assigning its route in the management UI.
+- Other requests and upstream HTTP errors pass through. Inference payloads,
+  service tiers, billing, SSE, and standard reverse-proxy WebSocket upgrades keep
+  their existing behavior. No inference requests are issued to probe models.
+
+Provider ownership is a coarse compatibility check. The routing response does
+not enumerate the models supported by each individual credential. This filter
+therefore cannot guarantee immediate callability or predict temporary quotas,
+cooldowns, network failures, missing model prices, or per-credential model
+differences. These remain request-time checks. Clients that merge server models
+with their own built-in lists may still show additional local entries.
+
+## Tests
+
+```sh
+go test -race ./internal/catalogproxy ./cmd/cpa-model-catalog-proxy
+```
+
+Tests cover concurrent per-key isolation, live routing changes, both catalog
+formats and all supported paths, provider intersection, metadata preservation,
+cache isolation, malformed responses, credential ambiguity, redirects, body
+limits, inference streams, and upstream authentication errors.

--- a/internal/catalogproxy/proxy.go
+++ b/internal/catalogproxy/proxy.go
@@ -1,0 +1,248 @@
+// Package catalogproxy filters CPA model discovery using Key Billing routing.
+// It runs in a separate HTTP process, outside the embedded plugin runtime.
+package catalogproxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+const routingPath = "/v0/resource/plugins/cpa-key-billing/routing"
+
+type permissions struct {
+	models map[string]bool
+	owners map[string]bool
+}
+
+// New forwards traffic to one CPA origin and filters successful model catalogs.
+func New(origin string) (*httputil.ReverseProxy, error) {
+	target, err := url.Parse(origin)
+	if err != nil || target == nil || (target.Scheme != "http" && target.Scheme != "https") || target.Host == "" ||
+		target.User != nil || (target.Path != "" && target.Path != "/") || target.RawQuery != "" || target.Fragment != "" {
+		return nil, fmt.Errorf("upstream must be an HTTP(S) origin without credentials, a path, query, or fragment")
+	}
+	target.Path = ""
+	client := &http.Client{
+		// A permissions redirect must never receive the caller's credential.
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse },
+	}
+	return &httputil.ReverseProxy{
+		Rewrite: func(request *httputil.ProxyRequest) {
+			request.SetURL(target)
+			if isCatalog(request.In) {
+				request.Out.Header.Set("Accept-Encoding", "identity")
+				request.Out.Header.Del("If-None-Match")
+				request.Out.Header.Del("If-Modified-Since")
+			}
+		},
+		ModifyResponse: func(response *http.Response) error {
+			if !isCatalog(response.Request) || response.StatusCode != http.StatusOK {
+				return nil
+			}
+			allowed, err := fetchPermissions(client, target, response.Request)
+			if err != nil {
+				return err
+			}
+			return filterCatalog(response, allowed)
+		},
+		ErrorHandler: func(writer http.ResponseWriter, _ *http.Request, _ error) {
+			// Upstream errors may contain URLs or headers; do not expose them.
+			writer.Header().Set("Cache-Control", "private, no-store")
+			http.Error(writer, "model catalog upstream unavailable", http.StatusBadGateway)
+		},
+	}, nil
+}
+
+func isCatalog(request *http.Request) bool {
+	if request == nil || request.Method != http.MethodGet {
+		return false
+	}
+	switch request.URL.Path {
+	case "/v1/models", "/models", "/backend-api/codex/models", "/codex/models":
+		return true
+	}
+	return false
+}
+
+func fetchPermissions(client *http.Client, target *url.URL, incoming *http.Request) (*permissions, error) {
+	endpoint := *target
+	endpoint.Path = routingPath
+	request, err := http.NewRequestWithContext(incoming.Context(), http.MethodGet, endpoint.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("create routing request")
+	}
+	key, err := callerKey(incoming)
+	if err != nil {
+		return nil, err
+	}
+	request.Header.Set("Authorization", "Bearer "+key)
+	response, err := client.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("fetch routing permissions")
+	}
+	body, err := readBody(response.Body, 1<<20)
+	if err != nil || response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("routing permissions unavailable")
+	}
+	var routing struct {
+		Valid       *bool    `json:"routing_valid"`
+		Models      []string `json:"models"`
+		Credentials []struct {
+			Provider string `json:"provider"`
+			Status   string `json:"status"`
+		} `json:"credentials"`
+	}
+	if json.Unmarshal(body, &routing) != nil || routing.Valid == nil || !*routing.Valid || routing.Models == nil || routing.Credentials == nil {
+		return nil, fmt.Errorf("invalid routing permissions")
+	}
+	allowed := &permissions{models: make(map[string]bool, len(routing.Models))}
+	for _, model := range routing.Models {
+		model = strings.ToLower(strings.TrimSpace(model))
+		if model == "" {
+			return nil, fmt.Errorf("invalid routing model ID")
+		}
+		allowed.models[model] = true
+	}
+	if len(routing.Credentials) > 0 {
+		allowed.owners = make(map[string]bool)
+		for _, credential := range routing.Credentials {
+			if credential.Status == "missing" || credential.Status == "disabled" {
+				continue
+			}
+			provider := strings.ToLower(strings.TrimSpace(credential.Provider))
+			if provider == "codex" {
+				provider = "openai"
+			}
+			if provider != "" {
+				allowed.owners[provider] = true
+			}
+		}
+	}
+	return allowed, nil
+}
+
+// Use one unambiguous credential for CPA authentication and routing lookup.
+func callerKey(request *http.Request) (string, error) {
+	var candidates []string
+	for _, authorization := range request.Header.Values("Authorization") {
+		parts := strings.Fields(authorization)
+		if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
+			return "", fmt.Errorf("invalid caller authentication")
+		}
+		candidates = append(candidates, parts[1])
+	}
+	for _, header := range []string{"X-Api-Key", "X-Goog-Api-Key"} {
+		candidates = append(candidates, request.Header.Values(header)...)
+	}
+	for _, parameter := range []string{"key", "api_key"} {
+		candidates = append(candidates, request.URL.Query()[parameter]...)
+	}
+	key := ""
+	for _, candidate := range candidates {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			continue
+		}
+		if len(candidate) > 8192 || (key != "" && candidate != key) {
+			return "", fmt.Errorf("ambiguous caller authentication")
+		}
+		key = candidate
+	}
+	if key == "" {
+		return "", fmt.Errorf("caller authentication required")
+	}
+	return key, nil
+}
+
+func readBody(body io.ReadCloser, limit int64) ([]byte, error) {
+	data, errRead := io.ReadAll(io.LimitReader(body, limit+1))
+	errClose := body.Close()
+	if errRead != nil || errClose != nil || int64(len(data)) > limit {
+		return nil, fmt.Errorf("invalid upstream body")
+	}
+	return data, nil
+}
+
+func filterCatalog(response *http.Response, allowed *permissions) error {
+	body, err := readBody(response.Body, 16<<20)
+	if err != nil {
+		return err
+	}
+	var catalog map[string]json.RawMessage
+	if json.Unmarshal(body, &catalog) != nil {
+		return fmt.Errorf("invalid model catalog")
+	}
+	found := false
+	for _, field := range []string{"data", "models"} {
+		raw, exists := catalog[field]
+		if !exists {
+			continue
+		}
+		found = true
+		var models []map[string]json.RawMessage
+		if json.Unmarshal(raw, &models) != nil || models == nil {
+			return fmt.Errorf("invalid model entries")
+		}
+		filtered := make([]map[string]json.RawMessage, 0, len(models))
+		for _, model := range models {
+			id := modelID(model)
+			if id == "" {
+				return fmt.Errorf("model identifier missing")
+			}
+			if len(allowed.models) > 0 && !allowed.models[strings.ToLower(id)] {
+				continue
+			}
+			if allowed.owners != nil {
+				var owner string
+				_ = json.Unmarshal(model["owned_by"], &owner)
+				// The native Codex catalog omits ownership and only contains Codex models.
+				if owner == "" && field == "models" {
+					owner = "openai"
+				}
+				if !allowed.owners[strings.ToLower(strings.TrimSpace(owner))] {
+					continue
+				}
+			}
+			filtered = append(filtered, model)
+		}
+		catalog[field], err = json.Marshal(filtered)
+		if err != nil {
+			return fmt.Errorf("encode filtered models")
+		}
+	}
+	if !found {
+		return fmt.Errorf("unsupported model catalog")
+	}
+	body, err = json.Marshal(catalog)
+	if err != nil {
+		return fmt.Errorf("encode model catalog")
+	}
+	response.Body = io.NopCloser(bytes.NewReader(body))
+	response.ContentLength = int64(len(body))
+	response.Header.Set("Content-Type", "application/json")
+	response.Header.Set("Content-Length", strconv.Itoa(len(body)))
+	response.Header.Set("Cache-Control", "private, no-store")
+	response.Header.Set("Pragma", "no-cache")
+	response.Header.Add("Vary", "Authorization, X-Api-Key, X-Goog-Api-Key")
+	for _, header := range []string{"ETag", "Last-Modified", "Content-MD5", "Digest"} {
+		response.Header.Del(header)
+	}
+	return nil
+}
+
+func modelID(model map[string]json.RawMessage) string {
+	for _, field := range []string{"id", "slug"} {
+		var id string
+		if json.Unmarshal(model[field], &id) == nil && strings.TrimSpace(id) != "" {
+			return strings.TrimSpace(id)
+		}
+	}
+	return ""
+}

--- a/internal/catalogproxy/proxy_test.go
+++ b/internal/catalogproxy/proxy_test.go
@@ -1,0 +1,309 @@
+package catalogproxy
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+func proxyServer(t *testing.T, handler http.HandlerFunc) (*httptest.Server, *httptest.Server) {
+	t.Helper()
+	upstream := httptest.NewServer(handler)
+	t.Cleanup(upstream.Close)
+	proxy, err := New(upstream.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(proxy)
+	t.Cleanup(server.Close)
+	return server, upstream
+}
+
+func catalogRequest(t *testing.T, server, path, key string) (int, http.Header, string) {
+	t.Helper()
+	request, err := http.NewRequest(http.MethodGet, server+path, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Authorization", "Bearer "+key)
+	request.Header.Set("If-None-Match", "old-catalog")
+	request.Header.Set("If-Modified-Since", "yesterday")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := readBody(response.Body, 1<<20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return response.StatusCode, response.Header, string(body)
+}
+
+func TestPerKeyCatalogsAndLiveRouting(t *testing.T) {
+	for _, path := range []string{"/v1/models", "/models", "/backend-api/codex/models", "/codex/models"} {
+		t.Run(path, func(t *testing.T) {
+			field, idField := "data", "id"
+			if strings.Contains(path, "codex") {
+				field, idField = "models", "slug"
+			}
+			var allowed atomic.Value
+			allowed.Store("alpha")
+			var routingCalls atomic.Int32
+			entries := []map[string]any{
+				{idField: "alpha", "owned_by": "openai", "context_window": 12345, "future": map[string]any{"enabled": true}},
+				{idField: "beta", "owned_by": "openai", "service_tiers": []string{"priority"}},
+			}
+			server, _ := proxyServer(t, func(w http.ResponseWriter, r *http.Request) {
+				key := r.Header.Get("Authorization")
+				if key != "Bearer dummy-a" && key != "Bearer dummy-b" {
+					w.WriteHeader(401)
+					return
+				}
+				if r.URL.Path == routingPath {
+					routingCalls.Add(1)
+					model := allowed.Load().(string)
+					if key == "Bearer dummy-b" {
+						model = "beta"
+					}
+					_ = json.NewEncoder(w).Encode(map[string]any{"routing_valid": true, "models": []string{model}, "credentials": []any{}})
+					return
+				}
+				if r.URL.Path != path || r.URL.Query().Get("client_version") != "test" || r.Header.Get("If-None-Match") != "" || r.Header.Get("If-Modified-Since") != "" || r.Header.Get("Accept-Encoding") != "identity" {
+					t.Error("catalog query or cache controls changed")
+				}
+				w.Header().Set("ETag", "shared")
+				w.Header().Set("Last-Modified", "old")
+				_ = json.NewEncoder(w).Encode(map[string]any{field: entries, "extra": "preserved"})
+			})
+			check := func(key, model string) {
+				status, headers, body := catalogRequest(t, server.URL, path+"?client_version=test", key)
+				var result map[string]json.RawMessage
+				if status != 200 || json.Unmarshal([]byte(body), &result) != nil {
+					t.Errorf("catalog status=%d body=%s", status, body)
+					return
+				}
+				var models []map[string]any
+				if json.Unmarshal(result[field], &models) != nil || len(models) != 1 || models[0][idField] != model {
+					t.Errorf("wrong key catalog: %s", body)
+					return
+				}
+				index := 0
+				if model == "beta" {
+					index = 1
+				}
+				wantJSON, _ := json.Marshal(entries[index])
+				var want map[string]any
+				_ = json.Unmarshal(wantJSON, &want)
+				if !reflect.DeepEqual(models[0], want) || string(result["extra"]) != `"preserved"` {
+					t.Error("catalog metadata changed")
+				}
+				if headers.Get("Cache-Control") != "private, no-store" || headers.Get("ETag") != "" || headers.Get("Last-Modified") != "" {
+					t.Error("catalog can be cached across callers")
+				}
+			}
+			var concurrent sync.WaitGroup
+			for range 6 {
+				concurrent.Add(2)
+				go func() { defer concurrent.Done(); check("dummy-a", "alpha") }()
+				go func() { defer concurrent.Done(); check("dummy-b", "beta") }()
+			}
+			concurrent.Wait()
+			allowed.Store("beta")
+			check("dummy-a", "beta")
+			if routingCalls.Load() != 13 {
+				t.Fatal("routing permissions were cached")
+			}
+		})
+	}
+}
+
+func TestCredentialProviderIntersection(t *testing.T) {
+	for _, test := range []struct {
+		name, routing, catalog string
+		want                   []string
+	}{
+		{"codex", `{"routing_valid":true,"models":[],"credentials":[{"provider":"codex","status":"active"}]}`, `{"data":[{"id":"alpha","owned_by":"openai"},{"id":"beta","owned_by":"antigravity"},{"id":"unknown"}]}`, []string{"alpha"}},
+		{"intersection", `{"routing_valid":true,"models":["BETA"],"credentials":[{"provider":"codex"}]}`, `{"data":[{"id":"alpha","owned_by":"openai"},{"id":"beta","owned_by":"antigravity"}]}`, []string{}},
+		{"native-codex", `{"routing_valid":true,"models":[],"credentials":[{"provider":"codex"}]}`, `{"models":[{"slug":"alpha"}]}`, []string{"alpha"}},
+		{"missing", `{"routing_valid":true,"models":[],"credentials":[{"provider":"codex","status":"missing"}]}`, `{"data":[{"id":"alpha","owned_by":"openai"}]}`, []string{}},
+		{"disabled", `{"routing_valid":true,"models":[],"credentials":[{"provider":"codex","status":"disabled"}]}`, `{"data":[{"id":"alpha","owned_by":"openai"}]}`, []string{}},
+		{"unrestricted", `{"routing_valid":true,"models":[],"credentials":[]}`, `{"data":[{"id":"alpha"},{"id":"beta"}]}`, []string{"alpha", "beta"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			server, _ := proxyServer(t, func(w http.ResponseWriter, r *http.Request) {
+				body := test.catalog
+				if r.URL.Path == routingPath {
+					body = test.routing
+				}
+				_, _ = io.WriteString(w, body)
+			})
+			status, _, body := catalogRequest(t, server.URL, "/v1/models", "dummy")
+			var result map[string][]map[string]json.RawMessage
+			if status != 200 || json.Unmarshal([]byte(body), &result) != nil {
+				t.Fatalf("status=%d body=%s", status, body)
+			}
+			got := []string{}
+			for _, field := range []string{"data", "models"} {
+				for _, model := range result[field] {
+					got = append(got, modelID(model))
+				}
+			}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("models=%v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestPermissionFailuresDoNotExposeCatalog(t *testing.T) {
+	for _, body := range []string{
+		`{}`, `not-json`, `{"routing_valid":false,"models":[],"credentials":[]}`,
+		`{"routing_valid":true,"models":null,"credentials":[]}`,
+		`{"routing_valid":true,"models":[],"credentials":null}`,
+		`{"routing_valid":true,"models":[""],"credentials":[]}`,
+	} {
+		server, _ := proxyServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == routingPath {
+				_, _ = io.WriteString(w, body)
+				return
+			}
+			_, _ = io.WriteString(w, `{"data":[{"id":"hidden-model"}]}`)
+		})
+		status, headers, result := catalogRequest(t, server.URL, "/v1/models", "dummy")
+		if status != 502 || strings.Contains(result, "hidden-model") || headers.Get("Cache-Control") != "private, no-store" {
+			t.Fatalf("permission failure exposed catalog: %d %s", status, result)
+		}
+	}
+}
+
+func TestRoutingRedirectIsNotFollowed(t *testing.T) {
+	var redirected atomic.Int32
+	destination := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { redirected.Add(1); w.WriteHeader(200) }))
+	defer destination.Close()
+	server, _ := proxyServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == routingPath {
+			http.Redirect(w, r, destination.URL, 302)
+			return
+		}
+		_, _ = io.WriteString(w, `{"data":[{"id":"hidden"}]}`)
+	})
+	status, _, _ := catalogRequest(t, server.URL, "/v1/models", "dummy")
+	if status != 502 || redirected.Load() != 0 {
+		t.Fatal("routing redirect received caller credentials")
+	}
+}
+
+func TestInferenceAndAuthenticationErrorsPassThrough(t *testing.T) {
+	var routingCalls atomic.Int32
+	server, _ := proxyServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == routingPath {
+			routingCalls.Add(1)
+			return
+		}
+		if r.URL.Path == "/v1/models" {
+			w.WriteHeader(401)
+			_, _ = io.WriteString(w, "dummy authentication error")
+			return
+		}
+		if r.Header.Get("Authorization") != "Bearer dummy" {
+			t.Error("inference credential changed")
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.Copy(w, r.Body)
+	})
+	status, _, body := catalogRequest(t, server.URL, "/v1/models", "dummy")
+	if status != 401 || body != "dummy authentication error" {
+		t.Fatal("CPA authentication error changed")
+	}
+	payload := "event: response.completed\ndata: {\"model\":\"fast-alias\",\"service_tier\":\"priority\"}\n\n"
+	request, _ := http.NewRequest(http.MethodPost, server.URL+"/v1/responses", strings.NewReader(payload))
+	request.Header.Set("Authorization", "Bearer dummy")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := readBody(response.Body, 1<<20)
+	if err != nil || string(data) != payload || response.Header.Get("Content-Type") != "text/event-stream" || routingCalls.Load() != 0 {
+		t.Fatal("non-catalog response changed")
+	}
+}
+
+func TestMalformedCatalogsAndBodyLimits(t *testing.T) {
+	for _, body := range []string{`{}`, `null`, `{"data":null}`, `{"data":[{}]}`, `{"data":[{"id":3}]}`} {
+		response := &http.Response{Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header)}
+		if err := filterCatalog(response, &permissions{}); err == nil {
+			t.Errorf("accepted malformed catalog %s", body)
+		}
+	}
+	if _, err := readBody(io.NopCloser(strings.NewReader("12345")), 4); err == nil {
+		t.Fatal("body limit ignored")
+	}
+	if body, err := readBody(io.NopCloser(strings.NewReader("1234")), 4); err != nil || string(body) != "1234" {
+		t.Fatal("exact body limit rejected")
+	}
+}
+
+func TestOriginValidation(t *testing.T) {
+	for _, origin := range []string{"", "file:///tmp", "ftp://host", "http://user:pass@host", "http://host/v1", "http://host?key=dummy", "http://host#fragment"} {
+		if _, err := New(origin); err == nil {
+			t.Errorf("accepted origin %q", origin)
+		}
+	}
+	for _, origin := range []string{"http://127.0.0.1:8317", "https://example.test/"} {
+		if _, err := New(origin); err != nil {
+			t.Errorf("rejected origin %q", origin)
+		}
+	}
+}
+
+func TestCallerCredentialFormsAndAmbiguity(t *testing.T) {
+	for _, header := range []string{"Authorization", "X-Api-Key", "X-Goog-Api-Key", "query"} {
+		t.Run(header, func(t *testing.T) {
+			server, _ := proxyServer(t, func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == routingPath {
+					if r.Header.Get("Authorization") != "Bearer dummy" || r.URL.RawQuery != "" {
+						t.Error("routing lookup did not use canonical caller credential")
+					}
+					_, _ = io.WriteString(w, `{"routing_valid":true,"models":[],"credentials":[]}`)
+					return
+				}
+				_, _ = io.WriteString(w, `{"data":[]}`)
+			})
+			request, _ := http.NewRequest(http.MethodGet, server.URL+"/v1/models", nil)
+			switch header {
+			case "Authorization":
+				request.Header.Set(header, "Bearer dummy")
+			case "query":
+				request.URL.RawQuery = "key=dummy"
+			default:
+				request.Header.Set(header, "dummy")
+			}
+			response, err := http.DefaultClient.Do(request)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, _ = readBody(response.Body, 1024)
+			if response.StatusCode != 200 {
+				t.Fatalf("credential form rejected: %d", response.StatusCode)
+			}
+		})
+	}
+	for _, alternate := range []string{"X-Api-Key", "X-Goog-Api-Key", "query"} {
+		request := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+		request.Header.Set("Authorization", "Bearer dummy-a")
+		if alternate == "query" {
+			request.URL.RawQuery = "key=dummy-b"
+		} else {
+			request.Header.Set(alternate, "dummy-b")
+		}
+		if _, err := callerKey(request); err == nil {
+			t.Fatal("conflicting keys could mix authentication and route scopes")
+		}
+	}
+}


### PR DESCRIPTION
Clients currently receive CPA's global model catalog even when Key Billing routes restrict their API key to a smaller model or credential-provider scope. This makes discovery advertise models that the key's route will reject.

Add an optional `cpa-model-catalog-proxy` companion that reads the current caller's existing Key Billing `/routing` response and filters OpenAI and native Codex catalogs. Model metadata is preserved, permissions are fetched on every request, and filtered responses cannot be shared through caches. The same unambiguous downstream credential is used for both CPA authentication and the routing lookup; missing permissions and redirects fail closed.

This runs as a separate HTTP process because CPA's execution interceptors do not intercept its model-list handlers. It requires no CPA changes and adds no plugin callbacks, resource routes, or embedded-runtime background work. The documentation includes direct-client and Nginx integration and keeps administrator discovery connected to the full CPA catalog.

Credential-provider ownership is a coarse filter, not a guarantee of immediate callability. Per-credential model differences, model pricing, temporary quotas and upstream availability remain request-time checks. The companion keeps inference payloads, service tiers, billing, and ordinary proxy behavior unchanged.

Validation:

- `go test -race ./...`, `go vet ./...`, `go mod tidy -diff`, and formatting checks
- Proxy and main CPA build checks
- Isolated CPA v7.2.154 + Key Billing v1.3.5 integration: 16 concurrent per-key catalog requests, live route changes, unrestricted scope, untracked-key failure, invalid-key rejection, and a complete direct CPA catalog
- No real inference requests or production changes

Tests cover all four supported catalog paths, both response formats, provider intersection, metadata preservation, credential ambiguity, redirect rejection, malformed/oversized bodies, cache isolation, inference streams, and upstream authentication errors.
